### PR TITLE
config.php: Set gamever to FFFF to bypass game update checks.

### DIFF
--- a/web/config.php
+++ b/web/config.php
@@ -151,6 +151,11 @@ for($i=0; $i<$targets_array_size; $i++)
 			<name>fpdver</name>
 			<new_value><?=$fpdverbase64?></new_value>
 		</requestoverride>
+		
+		<requestoverride type="postform">
+			<name>gamever</name>
+			<new_value>RkZGRg**</new_value>
+		</requestoverride>
 	</targeturl>
 
 	<targeturl> <!-- NNID -->


### PR DESCRIPTION
Tested with Pokemon Y and code-based Mystery Gifts, which require that the game has the latest update data. With any value at or above the current game version, the server will return a proper response and no longer error. Should also work with other games as well with lingering update requirement issues.
