### PR TITLE
Use httpcGetResponseStatusCodeTimeout

### DIFF
--- a/source/ctr-httpwn.c
+++ b/source/ctr-httpwn.c
@@ -439,7 +439,7 @@ Result download_config(char *url, u8 *cert, u32 certsize, u8 *filebuffer, u32 dl
 		return ret;
 	}
 
-	ret = httpcGetResponseStatusCode(&context, &statuscode);
+	ret = httpcGetResponseStatusCodeTimeout(&context, &statuscode, 30000000000);
 	if(R_FAILED(ret))
 	{
 		printf("httpcGetResponseStatusCode returned 0x%08x.\n", (unsigned int)ret);


### PR DESCRIPTION
Changes server connection timeout to 30 seconds, rather than the 3+ minute default that httpcGetResponseStatusCode will use.

The printf below it was not changed in order to allow the text to fit on one line.